### PR TITLE
Added YYYY to the format of the date label in the dataframe

### DIFF
--- a/tgt_vis.py
+++ b/tgt_vis.py
@@ -97,7 +97,7 @@ class compute_visibility():
         """Converts a datetime object's time to DOY.ddddd """
         datetime = time_object.datetime
         decimal_hours = datetime.hour + datetime.minute/ 60. + datetime.second/3600
-        return datetime.strftime("%j")+'.'+'{:7.5f}'.format(decimal_hours/24)[2:]
+        return datetime.strftime("%Y")+'-'+datetime.strftime("%j")+'.'+'{:7.5f}'.format(decimal_hours/24)[2:]
 
 
 


### PR DESCRIPTION
This fixes issue https://github.com/mgennaro/roman_visibility/issues/4
The attached screenshots show that a 366 days (or longer) interval can now be specified regardless of the start time being in a leap year or not.
<img width="1667" alt="Screenshot 2025-05-13 at 11 05 52 AM" src="https://github.com/user-attachments/assets/c5655e46-492d-4f3e-9f36-d8c0e9493528" />
<img width="1706" alt="Screenshot 2025-05-13 at 11 07 34 AM" src="https://github.com/user-attachments/assets/94222c07-66fc-429c-9bc7-98018f241f23" />
